### PR TITLE
Don't create sha-based docker tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
The image is based on `alpine:latest`, so an SHA-tag suggests a degree of reproduciblity that does not hold.